### PR TITLE
feat(web/contest_list): cosmetic changes

### DIFF
--- a/Web/static/dark.css
+++ b/Web/static/dark.css
@@ -501,17 +501,11 @@ html .contest--participant {
 html .contest--running {
     background-color: rgba(171, 205, 239, 0.1);
 }
-html .contest--pending {
-    background-color: rgba(255, 255, 255, 0.035);
-}
 html .table-striped tbody tr.contest--participant:nth-of-type(2n+1) {
     background-color: rgba(249, 230, 195, 0.15);
 }
 html .table-striped tbody tr.contest--running:nth-of-type(2n+1) {
     background-color: rgba(171, 205, 239, 0.15);
-}
-html .table-striped tbody tr.contest--pending:nth-of-type(2n+1) {
-    background-color: rgba(255, 255, 255, 0.06);
 }
 html .table-hover tbody tr.contest--participant:hover {
     background-color: rgba(249, 230, 195, 0.25);
@@ -519,10 +513,6 @@ html .table-hover tbody tr.contest--participant:hover {
 html .table-hover tbody tr.contest--running:hover {
     background-color: rgba(147, 177, 208, 0.25);
 }
-html .table-hover tbody tr.contest--pending:hover {
-    background-color: rgba(255, 255, 255, 0.075);
-}
-
 
 /* https://highlightjs.org/ */
 pre code.hljs {

--- a/Web/static/style.css
+++ b/Web/static/style.css
@@ -23997,28 +23997,19 @@ pre > code.highlight {
     background-color: #fdf5e6;
 }
 .contest--running {
-    background-color: rgba(171, 205, 239, 0.2);
-}
-.contest--pending {
-    background-color: rgba(0, 0, 0, 0.05);
+    background-color: #e6eefd;
 }
 .table-striped tbody tr.contest--participant:nth-of-type(2n+1) {
-    background-color: #f7eede;
+    background-color: #fbeccebb;
 }
 .table-striped tbody tr.contest--running:nth-of-type(2n+1) {
-    background-color: rgba(139, 167, 196, 0.2);
-}
-.table-striped tbody tr.contest--pending:nth-of-type(2n+1) {
-    background-color: rgba(0, 0, 0, 0.075);
+    background-color: #cedefbbb;
 }
 .table-hover tbody tr.contest--participant:hover {
     background-color: #e8dece;
 }
 .table-hover tbody tr.contest--running:hover {
-    background-color: rgba(134, 161, 189, 0.3);
-}
-.table-hover tbody tr.contest--pending:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: #cfd6e3;
 }
 
 .card-body {

--- a/Web/templates/contest_list.html
+++ b/Web/templates/contest_list.html
@@ -13,7 +13,7 @@
     <div class="card card-body">
         <h1 class="text-center">比赛列表</h1>
         <div class="table-responsive">
-            <table class="table table-bordered table-hover" id="contests">
+            <table class="table table-bordered table-hover" id="contest_list">
                 <thead>
                 <tr>
                     <th>ID</th>
@@ -64,7 +64,7 @@
 <script src="{{ url_for('.static', filename = 'lib/jszip.min.js') }}"></script>
 <script>
 $(function(){
-        var table = $("#contests").DataTable({
+        var table = $("#contest_list").DataTable({
             paging: false,
             info: false,
             ordering: false

--- a/Web/templates/contest_list.html
+++ b/Web/templates/contest_list.html
@@ -2,54 +2,51 @@
 
 {% set page='比赛列表' %}
 
+{% block head %}
+    <!-- <link rel="stylesheet" href="{{ url_for('.static', filename = 'lib/jquery.dataTables.min.css') }}"> -->
+    <link rel="stylesheet" href="{{ url_for('.static', filename = 'lib/dataTables.bootstrap4.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for('.static', filename = 'lib/buttons.dataTables.min.css') }}">
+    <link rel="stylesheet" href="{{ url_for('.static', filename = 'lib/buttons.bootstrap4.min.css') }}">
+{% endblock %}
+
 {% block content %}
     <div class="card card-body">
         <h1 class="text-center">比赛列表</h1>
         <div class="table-responsive">
-            <table class="table table-striped table-bordered table-hover">
+            <table class="table table-bordered table-hover" id="contests">
                 <thead>
                 <tr>
-                    <th>编号</th>
+                    <th>ID</th>
                     <th>比赛名称</th>
                     <th>开始时间</th>
                     <th>结束时间</th>
                     <th>状态</th>
-                    <th>报名</th>
                 </tr>
                 </thead>
                 {% for cur in Data -%}
                     <tr {%
                         if cur['Joined']
                     %} class="contest--participant" {%
-                        elif cur['Status'] == 'Going On'
-                    %} class="contest--running" {%
-                        elif cur['Status'] == 'Pending'
-                    %} class="contest--pending" {% endif %}>
+                        elif cur['Status'] != 'Finished'
+                    %} class="contest--running" {% endif %}>
                         <td>{{ cur['ID'] }}</td>
-                        <td><a href="/OnlineJudge/contest/{{ cur['ID'] }}">{{ cur['Title'] }}</a></td>
-                        <td>{{ cur['Start_Time'] }}</td>
-                        <td>{{ cur['End_Time'] }}</td>
-                        <td>{{ cur['Status'] }}</td>
-                        <td>
-                            {% if cur['Exam_Blocked'] -%}
-                                <button disabled class="btn btn-primary btn-sm">已于考试中</button>
-                            {%- else -%}
-                                {% if cur['Blocked'] -%}
-                                    {%- if cur['Joined'] -%}
-                                        <button disabled class="btn btn-primary btn-sm">已报名</button>
-                                    {%- else -%}
-                                        <!-- <button disabled class="btn btn-primary btn-sm">报名</button> -->
-                                    {%- endif %}
-                                {% else -%}
-                                    {%- if cur['Joined'] -%}
-                                        <button disabled class="btn btn-primary btn-sm">已报名</button>
-                                    {%- else -%}
-                                        <button id="join_button_{{ cur['ID'] }}" onclick="post_join({{ cur['ID'] }})" class="btn btn-primary btn-sm">报名
-                                        </button>
-                                    {%- endif -%}
+                        <td><div class="float-right">
+                            {% if cur['Blocked'] -%}
+                                {%- if cur['Joined'] -%}
+                                    <button disabled class="btn btn-primary btn-sm">已报</button>
+                                {%- else -%}
+                                    <!-- <button disabled class="btn btn-primary btn-sm">报名</button> -->
                                 {%- endif %}
-                        {%- endif %}
-                        </td>
+                            {% else -%}
+                                {%- if cur['Joined'] -%}
+                                    <button disabled class="btn btn-primary btn-sm">已报</button>
+                                {%- else -%}
+                                    <button id="join_button_{{ cur['ID'] }}" onclick="post_join({{ cur['ID'] }})" class="btn btn-primary btn-sm">报名</button>
+                            {%- endif -%}
+                    {%- endif %}</div><a href="/OnlineJudge/contest/{{ cur['ID'] }}">{{ cur['Title'] }}</a></td>
+                        <td>{{ cur['Start_Time'][:-3] }}</td>
+                        <td>{{ cur['End_Time'][:-3] }}</td>
+                        <td>{{ cur['Status'] }}</td>
                     </tr>
                 {%- endfor %}
             </table>
@@ -58,6 +55,21 @@
 {% endblock %}
 
 {% block script %}
-    <script src="{{ url_for('.static', filename = 'js/post_join.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'js/post_join.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/jquery.dataTables.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/dataTables.bootstrap4.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/dataTables.buttons.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/buttons.html5.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/buttons.bootstrap4.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/jszip.min.js') }}"></script>
+<script>
+$(function(){
+        var table = $("#contests").DataTable({
+            paging: false,
+            info: false,
+            ordering: false
+        });
+    });
+</script>
 {% endblock %}
 

--- a/Web/templates/homework_list.html
+++ b/Web/templates/homework_list.html
@@ -6,46 +6,40 @@
     <div class="card card-body">
         <h1 class="text-center"> 作业列表 </h1>
         <div class="table-responsive">
-            <table class="table table-striped table-bordered table-hover" id="homework_list">
+            <table class="table table-bordered table-hover" id="homework_list">
                 <thead>
                 <tr>
-                    <th>编号</th>
+                    <th>ID</th>
                     <th>作业名称</th>
                     <th>开始时间</th>
                     <th>结束时间</th>
                     <th>状态</th>
-                    <th>报名</th>
                 </tr>
                 </thead>
                 {% for cur in Data -%}
                     <tr {%
                         if cur['Joined']
                     %} class="contest--participant" {%
-                        elif cur['Status'] == 'Going On'
-                    %} class="contest--running" {%
-                        elif cur['Status'] == 'Pending'
-                    %} class="contest--pending" {% endif %}>
+                        elif cur['Status'] != 'Finished'
+                    %} class="contest--running" {% endif %}>
                         <td>{{ cur['ID'] }}</td>
-                        <td><a href="/OnlineJudge/homework/{{ cur['ID'] }}">{{ cur['Title'] }}</a></td>
-                        <td>{{ cur['Start_Time'] }}</td>
-                        <td>{{ cur['End_Time'] }}</td>
+                        <td><div class="float-right">{% if cur['Blocked'] -%}
+                            {%- if cur['Joined'] -%}
+                                <button disabled class="btn btn-primary btn-sm">已报</button>
+                            {%- else -%}
+                                <!-- <button disabled class="btn btn-primary btn-sm">报名</button> -->
+                            {%- endif -%}
+                        {% else -%}
+                            {%- if cur['Joined'] -%}
+                                <button disabled class="btn btn-primary btn-sm">已报</button>
+                            {%- else -%}
+                                <button id="join_button_{{ cur['ID'] }}" onclick="post_join({{ cur['ID'] }})" class="btn btn-primary btn-sm">报名</button>
+                            {%- endif -%}
+                        {%- endif %}</div>
+                            <a href="/OnlineJudge/homework/{{ cur['ID'] }}">{{ cur['Title'] }}</a></td>
+                        <td>{{ cur['Start_Time'][:-3] }}</td>
+                        <td>{{ cur['End_Time'][:-3] }}</td>
                         <td>{{ cur['Status'] }}</td>
-                        <td>
-                            {% if cur['Blocked'] -%}
-                                {%- if cur['Joined'] -%}
-                                    <button disabled class="btn btn-primary btn-sm">已报名</button>
-                                {%- else -%}
-                                    <!-- <button disabled class="btn btn-primary btn-sm">报名</button> -->
-                                {%- endif -%}
-                            {% else -%}
-                                {%- if cur['Joined'] -%}
-                                    <button disabled class="btn btn-primary btn-sm">已报名</button>
-                                {%- else -%}
-                                    <button id="join_button_{{ cur['ID'] }}" onclick="post_join({{ cur['ID'] }})" class="btn btn-primary btn-sm">报名
-                                    </button>
-                                {%- endif -%}
-                            {%- endif %}
-                        </td>
                     </tr>
                 {%- endfor %}
             </table>

--- a/Web/templates/homework_list.html
+++ b/Web/templates/homework_list.html
@@ -48,5 +48,20 @@
 {% endblock %}
 
 {% block script %}
-    <script src="{{ url_for('.static', filename = 'js/post_join.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'js/post_join.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/jquery.dataTables.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/dataTables.bootstrap4.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/dataTables.buttons.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/buttons.html5.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/buttons.bootstrap4.min.js') }}"></script>
+<script src="{{ url_for('.static', filename = 'lib/jszip.min.js') }}"></script>
+<script>
+$(function(){
+        var table = $("#homework_list").DataTable({
+            paging: false,
+            info: false,
+            ordering: false
+        });
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
The PR includes:
1. Remove `table-striped` in contest list and homework list;
2. Add search box for both;
3. Adjust highlight colors;
4. Float the 报名 button right to the name of the contest and remove the second-level time in the lists, so that it could save the right hand space and avoid line break in the contest name and time.

That said, as discussed before, the change of web ui should be careful. This PR works better IMO, but not necessarily true for everyone.