### PR TITLE
fix: submit again when returning to submit page

### DIFF
--- a/web/static/js/problem_submit.js
+++ b/web/static/js/problem_submit.js
@@ -24,6 +24,7 @@ $(function() {
             $("input").attr("disabled", "disabled");
         },
         success: function(response_text) {
+            $("input").removeAttr("disabled");
             location = `/OnlineJudge/code/${response_text}`
         },
     };


### PR DESCRIPTION
When returning to submit page from the status page (by going back in browser history), the user can't submit again. This is a common user scenario.
The cause is the `submit` button has been disabled.